### PR TITLE
- 【Nuget】版本更新到2.0.0-beta2

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@
 
 7. [Excel模板导出之导出教材订购表](docs/7.Excel模板导出之导出教材订购表.md "7.Excel模板导出之导出教材订购表")（[点此访问国内文档](https://docs.xin-lai.com/2020/01/08/%E7%BB%84%E4%BB%B6/Magicodes.IE/7.Excel%E6%A8%A1%E6%9D%BF%E5%AF%BC%E5%87%BA%E4%B9%8B%E5%AF%BC%E5%87%BA%E6%95%99%E6%9D%90%E8%AE%A2%E8%B4%AD%E8%A1%A8/)）
 
-8. 其他教程见下文或单元测试
+8. Excel导入之结果筛选器（待补充）
+9. 其他教程见下文或单元测试
 
 更新历史见下文。
 
@@ -175,6 +176,8 @@
 - [ ] 导入导出支持指定位置[CellAddress(Row = 2, Column = 2)]（[#19](https://github.com/dotnetcore/Magicodes.IE/issues/19)）
 - [ ] 生成的导入模板支持数据验证
 - [ ] 优化包依赖，拆解项目
+- [x] 导入结果筛选器
+- [ ] 导入列头筛选器
 
 ### 联系我们
 
@@ -203,6 +206,11 @@
 
 
 ### 更新历史
+
+#### 2019.02.04
+- 【Nuget】版本更新到2.0.0-beta2
+- 【导入】支持导入结果筛选器——IImportResultFilter，可用于多语言场景的错误标注，具体使用见单元测试【ImportResultFilter_Test】
+- 【其他】修改IExporterHeaderFilter的命名空间为Magicodes.ExporterAndImporter.Core.Filters
 
 #### 2019.01.18
 - 【Nuget】版本更新到2.0.0-beta1

--- a/common.props
+++ b/common.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.0.0-beta1</Version>
+    <Version>2.0.0-beta2</Version>
   </PropertyGroup>
   <PropertyGroup>
     <!--<TargetFramework>netstandard2.0</TargetFramework>-->

--- a/src/Magicodes.ExporterAndImporter.Core/Filters/IExporterHeaderFilter.cs
+++ b/src/Magicodes.ExporterAndImporter.Core/Filters/IExporterHeaderFilter.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-namespace Magicodes.ExporterAndImporter.Core
+namespace Magicodes.ExporterAndImporter.Core.Filters
 {
     /// <summary>
     /// 列头过滤

--- a/src/Magicodes.ExporterAndImporter.Core/Filters/IImportResultFilter.cs
+++ b/src/Magicodes.ExporterAndImporter.Core/Filters/IImportResultFilter.cs
@@ -1,0 +1,19 @@
+﻿using Magicodes.ExporterAndImporter.Core.Models;
+
+namespace Magicodes.ExporterAndImporter.Core.Filters
+{
+    /// <summary>
+    /// 导入结果筛选器
+    /// 可以处理标注内容
+    /// </summary>
+    public interface IImportResultFilter
+    {
+        /// <summary>
+        /// 处理导入结果
+        /// 比如对错误信息进行多语言转换
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        ImportResult<T> Filter<T>(ImportResult<T> importResult) where T : class, new();
+    }
+}

--- a/src/Magicodes.ExporterAndImporter.Core/IExporter.cs
+++ b/src/Magicodes.ExporterAndImporter.Core/IExporter.cs
@@ -14,6 +14,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Threading.Tasks;
+using Magicodes.ExporterAndImporter.Core.Filters;
 using Magicodes.ExporterAndImporter.Core.Models;
 
 namespace Magicodes.ExporterAndImporter.Core

--- a/src/Magicodes.ExporterAndImporter.Core/ImporterAttribute.cs
+++ b/src/Magicodes.ExporterAndImporter.Core/ImporterAttribute.cs
@@ -30,5 +30,11 @@ namespace Magicodes.ExporterAndImporter.Core
         /// 最大允许导入的函数
         /// </summary>
         public int MaxCount = 50000;
+
+
+        /// <summary>
+        /// 导入结果筛选器
+        /// </summary>
+        public Type ImportResultFilter { get; set; }
     }
 }

--- a/src/Magicodes.ExporterAndImporter.Excel/ExcelExporter.cs
+++ b/src/Magicodes.ExporterAndImporter.Excel/ExcelExporter.cs
@@ -21,6 +21,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Magicodes.ExporterAndImporter.Core;
 using Magicodes.ExporterAndImporter.Core.Extension;
+using Magicodes.ExporterAndImporter.Core.Filters;
 using Magicodes.ExporterAndImporter.Core.Models;
 using Magicodes.ExporterAndImporter.Excel.Utility;
 using Magicodes.ExporterAndImporter.Excel.Utility.TemplateExport;

--- a/src/Magicodes.ExporterAndImporter.Excel/Utility/ExportHelper.cs
+++ b/src/Magicodes.ExporterAndImporter.Excel/Utility/ExportHelper.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Linq.Dynamic.Core;
+using Magicodes.ExporterAndImporter.Core.Filters;
 
 namespace Magicodes.ExporterAndImporter.Excel.Utility
 {

--- a/src/Magicodes.ExporterAndImporter.Tests/ExcelImporter_Tests.cs
+++ b/src/Magicodes.ExporterAndImporter.Tests/ExcelImporter_Tests.cs
@@ -260,8 +260,26 @@ namespace Magicodes.ExporterAndImporter.Tests
             foreach (var item in result.RowErrors.GroupBy(p => p.RowIndex).Select(p => new { p.Key, Count = p.Count() }))
                 item.Count.ShouldBe(1);
 
-            char.Parse(",");
-            char.Parse("，");
+        }
+
+        [Fact(DisplayName = "结果筛选器测试")]
+        public async Task ImportResultFilter_Test()
+        {
+            var filePath = Path.Combine(Directory.GetCurrentDirectory(), "TestFiles", "Errors", "数据错误.xlsx");
+            var result = await Importer.Import<ImportResultFilterDataDto1>(filePath);
+            result.ShouldNotBeNull();
+            result.HasError.ShouldBeTrue();
+
+            result.TemplateErrors.Count.ShouldBe(0);
+
+            var errorRows = new List<int>()
+            {
+                5,6
+            };
+            result.RowErrors.ShouldContain(p =>
+                errorRows.Contains(p.RowIndex) && p.FieldErrors.ContainsKey("产品代码") &&
+                p.FieldErrors.Values.Contains("Duplicate data exists, please check! Where:5，6。"));
+
         }
 
         [Fact(DisplayName = "学生基础数据导入")]

--- a/src/Magicodes.ExporterAndImporter.Tests/Models/Import/ImportResultFilterDataDto1.cs
+++ b/src/Magicodes.ExporterAndImporter.Tests/Models/Import/ImportResultFilterDataDto1.cs
@@ -1,0 +1,67 @@
+﻿// ======================================================================
+// 
+//           filename : ImportRowDataErrorDto.cs
+//           description :
+// 
+//           created by 雪雁 at  2019-11-05 20:02
+//           文档官网：https://docs.xin-lai.com
+//           公众号教程：麦扣聊技术
+//           QQ群：85318032（编程交流）
+//           Blog：http://www.cnblogs.com/codelove/
+// 
+// ======================================================================
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Magicodes.ExporterAndImporter.Core;
+using Magicodes.ExporterAndImporter.Core.Filters;
+using Magicodes.ExporterAndImporter.Core.Models;
+
+namespace Magicodes.ExporterAndImporter.Tests.Models.Import
+{
+    public class ImportResultFilterTest : IImportResultFilter
+    {
+        /// <summary>
+        /// 本示例修改数据错误验证结果，可用于多语言等场景
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="importResult"></param>
+        /// <returns></returns>
+        public ImportResult<T> Filter<T>(ImportResult<T> importResult) where T : class, new()
+        {
+            var errorRows = new List<int>()
+            {
+                5,6
+            };
+            var items = importResult.RowErrors.Where(p => errorRows.Contains(p.RowIndex));
+            foreach (var (item, fieldError) in from item in items
+                                               from fieldError in item.FieldErrors
+                                               select (item, fieldError))
+            {
+                item.FieldErrors[fieldError.Key] = fieldError.Value.Replace("存在数据重复，请检查！所在行：", "Duplicate data exists, please check! Where:");
+            }
+
+            return importResult;
+        }
+    }
+
+    [Importer(ImportResultFilter = typeof(ImportResultFilterTest))]
+    public class ImportResultFilterDataDto1
+    {
+        /// <summary>
+        ///     产品名称
+        /// </summary>
+        [ImporterHeader(Name = "产品名称")]
+        public string Name { get; set; }
+
+        /// <summary>
+        ///     产品代码
+        ///     长度验证
+        ///     重复验证
+        /// </summary>
+        [ImporterHeader(Name = "产品代码", Description = "最大长度为20", AutoTrim = false, IsAllowRepeat = false)]
+        public string Code { get; set; }
+    }
+}

--- a/src/Magicodes.ExporterAndImporter.Tests/TestExporterHeaderFilter.cs
+++ b/src/Magicodes.ExporterAndImporter.Tests/TestExporterHeaderFilter.cs
@@ -1,4 +1,4 @@
-﻿using Magicodes.ExporterAndImporter.Core;
+﻿using Magicodes.ExporterAndImporter.Core.Filters;
 using Magicodes.ExporterAndImporter.Core.Models;
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
- 【导入】支持导入结果筛选器——IImportResultFilter，可用于多语言场景的错误标注，具体使用见单元测试【ImportResultFilter_Test】
- 【其他】修改IExporterHeaderFilter的命名空间为Magicodes.ExporterAndImporter.Core.Filters